### PR TITLE
chore: add domain meta README generator script

### DIFF
--- a/scripts/create_domain_meta_readmes.py
+++ b/scripts/create_domain_meta_readmes.py
@@ -76,8 +76,11 @@ def main():
         if readme.exists():
             print(f"Skipping existing: {readme}")
         else:
-            readme.write_text(content, encoding="utf-8")
-            print(f"Created: {readme}")
+            try:
+                readme.write_text(content, encoding="utf-8")
+                print(f"Created: {readme}")
+            except OSError as e:
+                print(f"Error creating {readme}: {e}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add Python helper to generate META/README.md stubs for all TFA domains

## Testing
- `make check` *(fails: Makefile:1: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68c22efa4ee483329f1f3065e8fccd2a

## Summary by Sourcery

Introduce a helper script that automates creation of standardized META/README.md templates for each TFA domain, simplifying domain documentation setup.

New Features:
- Add a Python script to generate META/README.md stubs for all TFA domains under 2-DOMAINS-LEVELS

Enhancements:
- Make the script idempotent by skipping existing README.md files and only creating missing ones