### PR TITLE
Add ISE documentation and second-pass test templates

### DIFF
--- a/2-DOMAINS-LEVELS/AAA-AERODYNAMICS-AND-AIRFRAMES-ARCHITECTURES/TFA/META/README.md
+++ b/2-DOMAINS-LEVELS/AAA-AERODYNAMICS-AND-AIRFRAMES-ARCHITECTURES/TFA/META/README.md
@@ -1,74 +1,40 @@
-# AAA — AERODYNAMICS-AND-AIRFRAMES-ARCHITECTURES · META
-
-**Breadcrumbs:**  
-[Portfolio Root](../../../../README.md) ›
-[2-DOMAINS-LEVELS](../../../../2-DOMAINS-LEVELS/) ›
-[AAA Domain](../../README.md) ›
-[TFA](../) › META
-
-**See also (sibling layers):**  
-[SYSTEMS/SI](../SYSTEMS/SI/) · [SYSTEMS/DI](../SYSTEMS/DI/) ·
-[STATIONS/SE](../STATIONS/SE/) ·
-[COMPONENTS/CV](../COMPONENTS/CV/) · [CE](../COMPONENTS/CE/) · [CC](../COMPONENTS/CC/) · [CI](../COMPONENTS/CI/) · [CP](../COMPONENTS/CP/) ·
-[BITS/CB](../BITS/CB/) ·
-[QUBITS/QB](../QUBITS/QB/) ·
-[ELEMENTS/UE](../ELEMENTS/UE/) · [FE](../ELEMENTS/FE/) ·
-[WAVES/FWD](../WAVES/FWD/) ·
-[STATES/QS](../STATES/QS/)
-
----
+# AAA — AERODYNAMICS-AND-AIRFRAMES-ARCHITECTURES
 
 ## Purpose & Scope
-This META page captures domain-level decisions, authorship, and references for AAA. Scope: aerodynamic configuration, airframe architecture trade space, performance targets, and structural integration with other domains.  
-**Domain index:** [AAA README](../../README.md) · **TFA index:** [AAA/TFA](../)
+This META page captures domain-level decisions, authorship, and references for AAA. Scope: aerodynamic configuration, airframe architecture trade space, performance targets, and structural integration with other domains.
 
 ## Domain Steward
 - Primary steward: [Team / Person Name]
 - Contact: [email]
-- Governance reference: [7-GOVERNANCE](../../../../7-GOVERNANCE/)
 
 ## Interfaces
-- **Upstream**
-  - [0-STRATEGY](../../../../0-STRATEGY/) (requirements)
-  - [1-CAX-METHODOLOGY](../../../../1-CAX-METHODOLOGY/) / *CAD-DESIGN (MBSE models)*  
-    Template: [8-RESOURCES/TEMPLATES/CAX-LIFECYCLE-TEMPLATES/CAD-DESIGN/README.template.md](../../../../8-RESOURCES/TEMPLATES/CAX-LIFECYCLE-TEMPLATES/CAD-DESIGN/README.template.md)
-- **Downstream**
-  - PPP (propulsion): [2-DOMAINS-LEVELS/PPP-PROPULSION-AND-FUEL-SYSTEMS](../../../../2-DOMAINS-LEVELS/PPP-PROPULSION-AND-FUEL-SYSTEMS/)
-  - CCC (cockpit/cabin): [2-DOMAINS-LEVELS/CCC-COCKPIT-CABIN-AND-CARGO](../../../../2-DOMAINS-LEVELS/CCC-COCKPIT-CABIN-AND-CARGO/)
-  - OPTIMO-DT (digital thread): [3-PROJECTS-USE-CASES/OPTIMO-DT](../../../../3-PROJECTS-USE-CASES/OPTIMO-DT/)
-- **Typical interface artifacts:** SysML models, ICDs, integration matrices — see **[SYSTEMS/SI](../SYSTEMS/SI/)**.
+- Upstream: 0-STRATEGY (requirements), 1-CAX-METHODOLOGY/CAD-DESIGN (MBSE models)
+- Downstream: PPP (propulsion), CCC (cockpit/cabin interfaces), OPTIMO-DT (digital-thread ingest)
+- Typical interface artifacts: SysML models, interface-control documents (ICD), integration matrices (SI layer)
 
 ## Compliance & Standards
-Applicable: EASA CS-25 / FAA Part 25, ARP4754A, DO-178C (avionics SW), DO-254 (FPGA/hardware), AS9100, S1000D.  
-Certification notes: track traceability in **[OPTIMO-DT](../../../../3-PROJECTS-USE-CASES/OPTIMO-DT/)** and register deviations in this **META**.
+- Applicable: EASA CS-25 / FAA Part 25, ARP4754A, DO-178C (avionics SW), DO-254 (FPGA/hardware), AS9100, S1000D for maintenance data.
+- Certification notes: Track traceability in OPTIMO-DT and register deviations in this META.
 
 ## Variants & Notable Items
 - Variant families: BWB-Q100, BWB-Q250, AMPEL360e
-- Notable: blended-wing-body aeroforms, distributed-propulsion structural interfaces  
-Related: **[PPP domain](../../../../2-DOMAINS-LEVELS/PPP-PROPULSION-AND-FUEL-SYSTEMS/)** for integration points.
+- Notable: blended-wing-body aeroforms, distributed propulsion structural interfaces
 
 ## Quantum Layers Map (local decisions)
-- **BITS/CB:** host classical solvers & config bits (CFD parameters) → [../BITS/CB/](../BITS/CB/)
-- **QUBITS/QB:** quantum-accelerated aero optimizers (QAOA/VQE prototypes) → [../QUBITS/QB/](../QUBITS/QB/)
-- **ELEMENTS/UE:** canonical geometric unit elements → [../ELEMENTS/UE/](../ELEMENTS/UE/)
-- **ELEMENTS/FE:** federation elements for cross-domain optimization → [../ELEMENTS/FE/](../ELEMENTS/FE/)
-- **WAVES/FWD:** predictive gust response models → [../WAVES/FWD/](../WAVES/FWD/)
-- **STATES/QS:** experiments registry → [../STATES/QS/](../STATES/QS/)
+- BITS/CB: host classical solvers & config bits (CFD parameters)
+- QUBITS/QB: reserved for quantum-accelerated aero optimizers (QAOA/VQE prototypes)
+- ELEMENTS/UE: canonical geometric unit elements
+- ELEMENTS/FE: federation elements for cross-domain optimization (e.g., aero-structures coupling)
+- WAVES/FWD: FWD models used for predictive gust response
+- STATES/QS: no active QS artifacts yet — record experiments here
 
 ## Local Decisions / Deviations
-- Local decision log: record deviation IDs, reasons, and approval dates here.  
-Cross-ref impacted layer(s): link e.g. **[SYSTEMS/DI](../SYSTEMS/DI/)**, **[COMPONENTS/CC](../COMPONENTS/CC/)**.
+- Local decision log: record deviation IDs, reasons, and approval dates here.
 
 ## Links / Templates
-- Domain templates: [`8-RESOURCES/TEMPLATES/DOMAIN-SPECIFIC-TEMPLATES/AAA-TEMPLATES/`](../../../../8-RESOURCES/TEMPLATES/DOMAIN-SPECIFIC-TEMPLATES/AAA-TEMPLATES/)
-- Example artifacts: [`3-PROJECTS-USE-CASES/BWB-Q100-AIRCRAFT/`](../../../../3-PROJECTS-USE-CASES/BWB-Q100-AIRCRAFT/)
+- Template bucket: `8-RESOURCES/TEMPLATES/DOMAIN-SPECIFIC-TEMPLATES/AAA-TEMPLATES/`
+- Example artifacts: `3-PROJECTS-USE-CASES/BWB-Q100-AIRCRAFT/`
 
-## Change Log
+## Change log
 - Created: [YYYY-MM-DD] by [author]
 - Last updated: [YYYY-MM-DD] — brief note
-
----
-
-### Navigation
-⬆ **Up:** [AAA/TFA index](../) • 🏠 **Domain:** [AAA README](../../README.md)  
-⟵ **Prev:** [SYSTEMS/SI](../SYSTEMS/SI/) • ⟶ **Next:** [SYSTEMS/DI](../SYSTEMS/DI/)

--- a/8-RESOURCES/TEMPLATES/MAL/FE/second_pass.test.py
+++ b/8-RESOURCES/TEMPLATES/MAL/FE/second_pass.test.py
@@ -1,0 +1,16 @@
+"""Template test to verify MAL-FE idempotency.
+Run MAL-FE twice with the same manifest; the second run must report no delta."""
+
+from pathlib import Path
+
+def apply_manifest(manifest: Path) -> dict:
+    """Placeholder for MAL-FE apply logic.
+    Returns a dict with a 'delta' key indicating if changes occurred."""
+    return {"delta": 0}
+
+def test_second_pass_no_delta(tmp_path: Path):
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text("actions: []", encoding="utf-8")
+    first = apply_manifest(manifest)
+    second = apply_manifest(manifest)
+    assert second["delta"] == 0

--- a/8-RESOURCES/TEMPLATES/MAL/FE/second_pass.test.py
+++ b/8-RESOURCES/TEMPLATES/MAL/FE/second_pass.test.py
@@ -10,7 +10,12 @@ def apply_manifest(manifest: Path) -> dict:
 
 def test_second_pass_no_delta(tmp_path: Path):
     manifest = tmp_path / "manifest.yaml"
-    manifest.write_text("actions: []", encoding="utf-8")
+    manifest.write_text(
+        "actions:\n"
+        "  - name: example_action\n"
+        "    type: noop\n",
+        encoding="utf-8"
+    )
     first = apply_manifest(manifest)
     second = apply_manifest(manifest)
     assert second["delta"] == 0

--- a/8-RESOURCES/TEMPLATES/MAL/FE/second_pass.yaml
+++ b/8-RESOURCES/TEMPLATES/MAL/FE/second_pass.yaml
@@ -1,0 +1,7 @@
+# MAL-FE second-pass test template
+# Run MAL-FE apply twice; the second run should report no changes.
+actions:
+  - name: ensure:config
+    idempotent_key: example.domain/config
+    params:
+      key: value

--- a/8-RESOURCES/TEMPLATES/MAL/FWD/second_pass.test.py
+++ b/8-RESOURCES/TEMPLATES/MAL/FWD/second_pass.test.py
@@ -1,0 +1,14 @@
+"""Template test to verify MAL-FWD idempotency.
+Calling forecast twice with the same parameters should not change state."""
+
+from pathlib import Path
+
+def forecast(params: dict) -> dict:
+    """Placeholder for MAL-FWD forecast logic."""
+    return {"delta": 0}
+
+def test_second_pass_forecast_no_delta():
+    params = {"horizon": "1h"}
+    first = forecast(params)
+    second = forecast(params)
+    assert second["delta"] == 0

--- a/8-RESOURCES/TEMPLATES/MAL/FWD/second_pass.yaml
+++ b/8-RESOURCES/TEMPLATES/MAL/FWD/second_pass.yaml
@@ -1,0 +1,6 @@
+# MAL-FWD second-pass test template
+# Execute MAL-FWD forecast twice; subsequent runs should yield no additional updates.
+forecast:
+  horizon: 1h
+  parameters:
+    sample: value

--- a/docs/intent-agent-idempotent.md
+++ b/docs/intent-agent-idempotent.md
@@ -81,7 +81,7 @@ canonical_hash: "0x..."   # keccak256(JSON canónico)
 
 ### 4.2 Sistema Agente (contrato MAL)
 
-```
+```yaml
 agent:
   name: "MAL-FE"
   policy:

--- a/docs/intent-agent-idempotent.md
+++ b/docs/intent-agent-idempotent.md
@@ -1,0 +1,176 @@
+# Intención → Sistema Agente → Estado Idempotente (ISE)
+**Norma canónica para agentes idempotentes en TFA/AQUA**
+
+> Entre la **Intención** (qué) y el **Estado Idempotente** (resultado) se sitúa el **Sistema Agente** (cómo), el medio de *consecutio* que observa, compara y actúa para cerrar el delta de forma segura y repetible.
+
+[Quantum–Classical Bridge](../docs/quantum-classical-bridge.md) · [TFA Architecture](../8-RESOURCES/TFA-ARCHITECTURE.md) · [Plantillas TFA](../8-RESOURCES/TEMPLATES/) · [AQUA App](../services/aqua-webhook/README.md) · [AQUA-OS PRO](../services/aqua-os-pro/AQUA-OS-PRO-SPEC.md)
+
+---
+
+## 1. Resumen
+- **Intención**: objetivo **declarativo** del estado final.
+- **Sistema Agente (SA)**: lazo **Observar → Comparar → Actuar (OCA)** que ejecuta solo el **delta** necesario.
+- **Estado Idempotente**: realidad estabilizada; ejecuciones repetidas no producen cambios.
+
+**Principio**: Si la Intención ya coincide con la Realidad, el SA **no actúa**.
+
+---
+
+## 2. Mapeo ISE ↔ TFA/MAP/MAL
+- **Intención**  
+  - Se materializa como **manifiestos canónicos** TFA en `TFA/*/META/` (p. ej. FE/QS/CE).  
+  - Puede vivir en **FE** (orquestaciones multi-elemento) o **QS** (estados medidos/simulados).  
+  - Firmas **EIP-712** para Intenciones de Federación (FE).
+
+- **Sistema Agente (medio de consecutio)**  
+  - **MAL-\***: servicios horizontales (CB/QB/UE/FE/FWD/QS) que ejecutan el delta.  
+  - **MAP-\***: control de dominio (AAA, PPP, IIS, …) que llama a MAL-\* según políticas.  
+  - **AQUA**: valida manifiestos, verifica FE y **desencadena** anclaje UTCS/TEKNIA vía CI.
+
+- **Estado Idempotente**  
+  - Artefactos estabilizados en `TFA/STATES/QS/` o configuraciones efectivas en `TFA/*/*`.  
+  - Evidencia: pruebas, logs, anclaje **UTCS**, eventos de auditoría AQUA.
+
+---
+
+## 3. Lazo OCA (Observe–Compare–Act)
+```mermaid
+flowchart LR
+  I[Intención (manifest)] --> C{Comparar\nIntención vs Realidad}
+  R[Realidad actual] --> C
+  C -- Delta = 0 --> N[No acción]
+  C -- Delta > 0 --> A[Actuar (transacciones idempotentes)]
+  A --> V[Verificar & Registrar]
+  V --> R2[Realidad actualizada]
+  R2 --> C
+
+Invariantes de Idempotencia
+1.Conmutatividad parcial: re-ejecutar acciones no cambia el resultado final.
+2.Efecto nulo en convergencia: si Delta=0, no hay efectos laterales.
+3.Determinismo observable: misma Intención + misma Realidad ⇒ mismo resultado.
+4.Prueba de fijación: la segunda pasada del lazo no produce cambios materiales.
+```
+
+⸻
+
+## 4. Contratos (normativos)
+
+### 4.1 Intención (manifest mínimo)
+
+```
+artifact_id: "uuid-v4 | nombre-canonico"
+llc_code: "FE"           # o QS/CE/…
+domain: "AAA-AERODYNAMICS-AND-AIRFRAMES-ARCHITECTURES"
+goal:                    # estado deseado (declarativo)
+  config: { key: value }
+  constraints: [S1000D, MBSE]
+timestamp: "RFC3339"
+version: "1.0.0"
+provenance: { repo_paths: [...], cids: [...] }
+fe_signatures:
+  - signer: "0xSigner"
+    signature: "0x..."
+    eip712: { /* types/domain */ }
+canonical_hash: "0x..."   # keccak256(JSON canónico)
+```
+
+**Reglas**
+   •   El goal es declarativo (no procedimental).
+   •   canonical_hash debe verificar; la CI bloquea si no.
+   •   FE requiere ≥1 firma válida (EIP-712).
+
+### 4.2 Sistema Agente (contrato MAL)
+
+```
+agent:
+  name: "MAL-FE"
+  policy:
+    safety: ["dry-run-default", "bounded-rollback", "rate-limit"]
+    retries: { max: 2, jitter_ms: 150 }
+    quorum: "FE.quorum >= 2/3"
+  actions:
+    - name: "ensure:config"
+      idempotent_key: "domain/llc/config@hash"
+      preconditions: ["Delta>0"]
+      effect: "mutación mínima que reduce Delta"
+  observability:
+    emit: ["artifact.validated","fe.signature.verified","delta.applied","state.converged"]
+```
+
+### 4.3 Estado Idempotente (evidencias)
+   •   tests/ que demuestren segunda pasada nula.
+   •   events/ con state.converged.
+   •   UTCS anchor (testnet→mainnet) y hash canónico en cadena.
+
+⸻
+
+## 5. Patrones de diseño
+   •   Delta mínimo aplicable (DMA): dividir objetivos en mutaciones atómicas con idempotent_key.
+   •   Capas protectoras: dry-run, límites de radio de acción, rate-limit.
+   •   Lecturas fuertes antes de actuar (evitar TOCTTOU).
+   •   Compensaciones declarativas (no “deshacer” implícito).
+   •   Detección de drift continua (OPTIMO-DT ↔ QS).
+
+⸻
+
+## 6. Ejemplos
+
+### 6.1 Config línea única (archivo)
+
+Intención: “STATUS=ACTIVE existe exactamente una vez”
+Agente: MAL-CB (filesystem)
+Estado: archivo converge; re-ejecución no cambia bytes.
+
+### 6.2 Kubernetes (controlador)
+
+Intención: replicas: 3
+Agente: controlador MAP-IIS → MAL-UE
+Estado: Deployment converge; reconciliaciones posteriores no cambian recursos.
+
+### 6.3 AQUA-OS PRO (rutas)
+
+Intención: “fleet schedule ≤ SLA y rutas válidas”
+Agente: MAL-FWD/MAL-FE con PRO orquestador
+Estado: plan vigente firmado (FE) + utcs.anchor.requested emitido.
+
+⸻
+
+## 7. CI/CD (validación automática)
+   •   Validar JSON Schema + canonical_hash.
+   •   Simulación dry-run: Delta esperado = 0 en segunda pasada.
+   •   Condiciones de merge: check_run:success + pruebas de idempotencia verdes.
+   •   Para FE con utcs_candidate: disparar anchor_utcs (testnet).
+
+⸻
+
+## 8. SLOs de agentes
+   •   Convergencia: p95 < X s (por dominio).
+   •   Delta cero: ≥ 99.9% en re-ejecución inmediata.
+   •   Seguridad: 0 incidentes de “sobre-aplicación” por 10k acciones.
+   •   Trazabilidad: 100% eventos state.converged correlables a intención.
+
+⸻
+
+## 9. Plantillas y enlaces
+   •   Esquemas: 8-RESOURCES/TEMPLATES/.../artifact-manifest.schema.json
+   •   FE/QS: 8-RESOURCES/TEMPLATES/TFA-LAYER-TEMPLATES/ELEMENTS/FE/ · .../STATES/QS/
+   •   Agentes: services/aqua-webhook/, services/aqua-os-pro/
+   •   EIP-712: docs/eip712.md
+
+⸻
+
+## 10. Checklist de calidad (pre-merge)
+   •   Manifiesto válido y firmado (si FE)
+   •   canonical_hash verificado
+   •   Pruebas de segunda pasada = sin cambios
+   •   Eventos de auditoría presentes
+   •   (Opcional) utcs_candidate preparado para anclaje
+
+⸻
+
+## 11. Glosario mínimo
+   •   Medio de consecutio: mecanismo que realiza la transición desde la intención al estado final (el Sistema Agente).
+   •   Idempotencia: aplicar una instrucción múltiples veces produce el mismo estado final.
+   •   OCA: ciclo Observar–Comparar–Actuar.
+
+⸻

--- a/docs/intent-agent-idempotent.md
+++ b/docs/intent-agent-idempotent.md
@@ -57,7 +57,7 @@ Invariantes de Idempotencia
 
 ### 4.1 Intención (manifest mínimo)
 
-```
+```yaml
 artifact_id: "uuid-v4 | nombre-canonico"
 llc_code: "FE"           # o QS/CE/…
 domain: "AAA-AERODYNAMICS-AND-AIRFRAMES-ARCHITECTURES"

--- a/docs/intent-agent-idempotent.md
+++ b/docs/intent-agent-idempotent.md
@@ -45,10 +45,10 @@ flowchart LR
   R2 --> C
 
 Invariantes de Idempotencia
-1.Conmutatividad parcial: re-ejecutar acciones no cambia el resultado final.
-2.Efecto nulo en convergencia: si Delta=0, no hay efectos laterales.
-3.Determinismo observable: misma Intención + misma Realidad ⇒ mismo resultado.
-4.Prueba de fijación: la segunda pasada del lazo no produce cambios materiales.
+1. Conmutatividad parcial: re-ejecutar acciones no cambia el resultado final.
+2. Efecto nulo en convergencia: si Delta=0, no hay efectos laterales.
+3. Determinismo observable: misma Intención + misma Realidad ⇒ mismo resultado.
+4. Prueba de fijación: la segunda pasada del lazo no produce cambios materiales.
 ```
 
 ⸻


### PR DESCRIPTION
## Summary
- Document Intention → Sistema Agente → Estado Idempotente (ISE) workflow
- Provide second-pass test templates for MAL-FE and MAL-FWD services
- Normalize AAA domain META README with concise scope and links

## Testing
- `make check`
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68c5661388e48332b95af70b96a6e500

## Summary by Sourcery

Document the Intention → Agent → Idempotent State (ISE) workflow, add second-pass idempotency test templates for MAL-FE and MAL-FWD services, and normalize the AAA domain TFA META README with concise scope and links.

New Features:
- Add detailed ISE specification document outlining Intention, Agent, and Idempotent State contracts and patterns

Enhancements:
- Streamline AAA TFA/META README by pruning breadcrumbs and refocusing on purpose, interfaces, and standards

Documentation:
- Introduce canonical ISE documentation under docs/intent-agent-idempotent.md

Tests:
- Include Python and YAML second-pass test templates to verify MAL-FE and MAL-FWD idempotency