### PR TITLE
feat: add BLG domain wall waveguide idea and meta README generator

### DIFF
--- a/4-RESEARCH-DEVELOPMENT/EDI_CQH/BLG-DW-Waveguides/IDEA_SUBMISSION.md
+++ b/4-RESEARCH-DEVELOPMENT/EDI_CQH/BLG-DW-Waveguides/IDEA_SUBMISSION.md
@@ -1,0 +1,80 @@
+Idea Submission: Tunable AB/BA Domain-Wall Waveguides in Bilayer Graphene for Reconfigurable 1D Quantum Channels
+
+Submitter: Amedeo Pelliccia
+Date: 2025-09-13
+Domain: EDI · CQH · OOO (Electronics & Digital Instruments · Cryogenics/Quantum Interfaces · Operating Systems/Navigation/HPC)
+Priority: High
+
+## Problem Statement
+
+AB/BA boundaries (structural twins) in bilayer graphene (BLG) are widely studied for valley-polarized chiral channels. However, device-grade guidance on non-chiral 1D states—arising when DW width and interlayer bias tune confinement and when 1D bands hybridize with the 2D continuum—is scarce. We lack:
+
+- A width–bias–field design map predicting when DWs host (i) low-energy confined non-chiral modes vs (ii) higher-energy quasi-bound states.
+- Fabrication recipes to reproducibly set DW width (soliton profile/strain control) and achieve dual-gate interlayer bias with clean encapsulation.
+- Measurement protocols linking spectroscopy/transport signatures (Landau fans, conductance steps, quasi-bound resonances) to the model.
+
+This blocks the use of DWs as reconfigurable, low-power, radiation-tolerant on-chip waveguides for avionics-grade cryogenic/quantum electronics.
+
+## Proposed Solution
+
+Deliver a model-to-hardware pipeline that co-designs DW width w, interlayer bias U, and magnetic field B to realize switchable 1D channels:
+
+1. **Theory & Simulation (OOO → OPTIM-DT)**
+   - Continuum Dirac + interlayer coupling for BLG with spatially varying stacking; validate with tight-binding.
+   - Compute dispersion, mode localization length, and coupling into 2D continuum vs (w, U, B).
+   - Transport via KWANT/NEGF to extract conductance plateaus, valley polarization, and Q-factors of quasi-bound modes.
+   - Output: Design map highlighting confined vs quasi-bound regimes (e.g., w\sim 2–30\,\mathrm{nm}, U\sim 0–200\,\mathrm{meV}, B=0–10\,\mathrm{T}).
+2. **Device Fabrication (EDI · CQH)**
+   - h-BN encapsulated BLG, deterministic stacking; create AB/BA DWs by controlled strain/soliton engineering or local gates.
+   - Dual graphite gates for clean U control; e-beam-defined contacts and local top gates for DW addressing.
+   - Optional nano-split gates to tune effective DW width electrostatically.
+3. **Cryogenic Characterization (CQH)**
+   - 1.5–10 K magneto-transport: look for 1D channel onset, bias-tunable mode count, Fabry–Pérot-like resonances (quasi-bound states).
+   - STM/STS on sister samples: confirm LDOS confinement at DW, track band crossover into 2D continuum with U and B.
+4. **Control & Integration (IIS · EDI)**
+   - Gate-bias control logic for on-demand switching between chiral and non-chiral regimes.
+   - Radiation-tolerance screening and variability analysis for aerospace use cases.
+
+## Expected Impact
+
+- **Technical:** A reproducible DW waveguide primitive: gate-defined, low-loss 1D interconnects with selectable chirality and tunable coupling to the 2D bath. Enables valleytronic routing, filters, and mixers at cryo.
+- **Business:** Foundational IP for reconfigurable interconnects in quantum-ready avionics and sensors (mass/power savings, simplified interposer layouts). Positions portfolio for partnerships in quantum-classical edge hardware.
+- **AQUA/QS:** Clear CB→QB bridge: classical control (CB) dynamically configures quasi-1D quantum channels (QB), advancing the QS (Quantum Superposition) capability within CQH/EDI stacks.
+
+## Resource Requirements
+
+- **People (core):** 1 PI (quantum/2D materials), 1 device physicist, 1 fabrication engineer, 1 modeling/NEGF specialist, 1 test engineer.
+- **Time:** 12–18 months (M1–M6 modeling & mask; M4–M12 fab; M8–M18 measurements & iterations).
+- **Tools / Capex:**
+  - Modeling: Python/Julia TB + NEGF (KWANT), continuum solvers; HPC queue (OOO).
+  - Fab: dry transfer, e-beam, reactive etch, metal evap; h-BN/BLG stacks; dual-gate process.
+  - Test: cryostat (≤1.5–10 K), up to 9–14 T magnet, low-noise electronics; optional STM/STS.
+- **Ops:** Cleanroom access (≥2 runs), consumables, wafers, probes; data pipeline into OPTIM-DT.
+
+## Success Criteria
+
+- **S1 (Model):** Published design map predicting confined vs quasi-bound regimes; open datasets & scripts.
+- **S2 (Spectroscopy/Transport):**
+  - Observation of low-energy non-chiral confined modes at targeted w,U with localization to the DW (STS LDOS contrast ≥ 5× vs domains).
+  - Quasi-bound resonances when 1D bands cross the 2D continuum; extracted Q-factor ≥ 20 at 4 K.
+  - Bias-controlled mode switching on/off ratio ≥ 10³; ballistic segment ≥ 1 µm.
+- **S3 (System):** Prototype DW interconnect demonstrating routing/switching at sub-µs gate update; reproducibility across ≥ 3 chips.
+- **S4 (Aerospace Readiness):** Preliminary radiation/thermal cycling data meeting CQH/IIS acceptance thresholds.
+
+## Risk Assessment
+
+- **Valley mixing & disorder** → h-BN encapsulation, ultra-clean transfer, minimize edge roughness; post-fab current anneal.
+- **DW width variability** → strain-soliton calibration via Raman/AFM; add electrostatic width-trim gates.
+- **Gate leakage/drift** → use graphite gates + high-quality dielectrics; bake-out and passivation protocols.
+- **Model–hardware mismatch** → close loop with OPTIM-DT: fit TB parameters to STS/transport, iterate masks.
+
+## TFA Integration Point
+
+- **Domains:**
+  - EDI (device stack, control electronics), CQH (cryogenic/quantum interfaces), OOO (HPC modeling & data), IIS (control logic/agents).
+- **Layers & Bridges:**
+  - SYSTEMS/SI: DW-waveguide subsystem integration with cryo platform.
+  - COMPONENTS/CI: BLG DW channel + dual-gate stack.
+  - BITS/CB→QB: Gate control (CB) configuring quantum transport channels (QB).
+  - FE (Federation Entanglement): Link device artifacts to simulation & test datasets across domains.
+  - FWD/QS: Operating envelope surfaces over (w,U,B,T) with QS metrics for mode purity and stability.

--- a/4-RESEARCH-DEVELOPMENT/EDI_CQH/BLG-DW-Waveguides/simulations/dw_transport.py
+++ b/4-RESEARCH-DEVELOPMENT/EDI_CQH/BLG-DW-Waveguides/simulations/dw_transport.py
@@ -1,0 +1,64 @@
+import kwant
+import numpy as np
+from scipy.sparse.linalg import eigsh
+
+
+class BLG_DW_System:
+    """Bilayer graphene domain wall transport simulator"""
+
+    def __init__(self, width=10, length=100, U_bias=0.1, B_field=0):
+        self.a = 0.246  # nm, lattice constant
+        self.t0 = 2.7    # eV, intralayer hopping
+        self.t1 = 0.4    # eV, interlayer hopping
+        self.width = width
+        self.length = length
+        self.U = U_bias
+        self.B = B_field
+
+    def make_system(self):
+        """Build KWANT system with AB/BA domain wall"""
+        lat = kwant.lattice.general(
+            [(self.a, 0), (self.a/2, self.a*np.sqrt(3)/2)],
+            [(0, 0), (self.a/3, self.a*np.sqrt(3)/3)]  # A1,B1 sublattices
+        )
+
+        sys = kwant.Builder()
+
+        # Domain wall profile: tanh transition
+        def stacking_phase(x):
+            return np.tanh(x / (self.width * self.a))
+
+        def onsite(site):
+            x, y = site.pos
+            layer = site.family  # 0:A1, 1:B1, 2:A2, 3:B2
+            bias = self.U/2 if layer < 2 else -self.U/2
+            return bias
+
+        # Define scattering region with DW
+        sys[(lat(i, j) for i in range(self.length)
+             for j in range(self.width))] = onsite
+
+        # Add magnetic field via Peierls substitution
+        if self.B > 0:
+            # Implementation of vector potential...
+            pass
+
+        return sys.finalized()
+
+    def compute_transport(self, energies):
+        """Calculate conductance vs energy"""
+        sys = self.make_system()
+        conductances = []
+
+        for E in energies:
+            smatrix = kwant.smatrix(sys, E)
+            G = smatrix.transmission(1, 0)  # Lead 0 to Lead 1
+            conductances.append(G)
+
+        return np.array(conductances)
+
+    def extract_modes(self):
+        """Find confined and quasi-bound states"""
+        # Eigenvalue solver for bound states
+        # Returns: energies, wavefunctions, localization_lengths
+        pass

--- a/4-RESEARCH-DEVELOPMENT/EDI_CQH/BLG-DW-Waveguides/simulations/dw_transport.py
+++ b/4-RESEARCH-DEVELOPMENT/EDI_CQH/BLG-DW-Waveguides/simulations/dw_transport.py
@@ -38,10 +38,7 @@ class BLG_DW_System:
         sys[(lat(i, j) for i in range(self.length)
              for j in range(self.width))] = onsite
 
-        # Add magnetic field via Peierls substitution
-        if self.B > 0:
-            # Implementation of vector potential...
-            pass
+        # Magnetic field support not yet implemented.
 
         return sys.finalized()
 

--- a/4-RESEARCH-DEVELOPMENT/EDI_CQH/BLG-DW-Waveguides/simulations/dw_transport.py
+++ b/4-RESEARCH-DEVELOPMENT/EDI_CQH/BLG-DW-Waveguides/simulations/dw_transport.py
@@ -31,7 +31,8 @@ class BLG_DW_System:
         def onsite(site):
             x, y = site.pos
             layer = site.family  # 0:A1, 1:B1, 2:A2, 3:B2
-            bias = self.U/2 if layer < 2 else -self.U/2
+            # Position-dependent bias using stacking_phase(x)
+            bias = (self.U/2 if layer < 2 else -self.U/2) * stacking_phase(x)
             return bias
 
         # Define scattering region with DW

--- a/scripts/create_meta_readmes.py
+++ b/scripts/create_meta_readmes.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""Generate META README stubs for all domains.
+
+Creates 2-DOMAINS-LEVELS/<DOMAIN>/TFA/META/README.md files
+if missing. Content matches provided stubs. Idempotent: skips
+existing files.
+"""
+from pathlib import Path
+
+def main():
+    root = Path('.').resolve()
+    stubs = {
+        "AAA-AERODYNAMICS-AND-AIRFRAMES-ARCHITECTURES": """# AAA — AERODYNAMICS-AND-AIRFRAMES-ARCHITECTURES
+
+## Purpose & Scope
+This META page captures domain-level decisions, authorship, and references for AAA. Scope: aerodynamic configuration, airframe architecture trade space, performance targets, and structural integration with other domains.
+
+## Domain Steward
+- Primary steward: [Team / Person Name]
+- Contact: [email]
+
+## Interfaces
+- Upstream: 0-STRATEGY (requirements), 1-CAX-METHODOLOGY/CAD-DESIGN (MBSE models)
+- Downstream: PPP (propulsion), CCC (cockpit/cabin interfaces), OPTIMO-DT (digital-thread ingest)
+- Typical interface artifacts: SysML models, interface-control documents (ICD), integration matrices (SI layer)
+
+## Compliance & Standards
+- Applicable: EASA CS-25 / FAA Part 25, ARP4754A, DO-178C (avionics SW), DO-254 (FPGA/hardware), AS9100, S1000D for maintenance data.
+- Certification notes: Track traceability in OPTIMO-DT and register deviations in this META.
+
+## Variants & Notable Items
+- Variant families: BWB-Q100, BWB-Q250, AMPEL360e
+- Notable: blended-wing-body aeroforms, distributed propulsion structural interfaces
+
+## Quantum Layers Map (local decisions)
+- BITS/CB: host classical solvers & config bits (CFD parameters)
+- QUBITS/QB: reserved for quantum-accelerated aero optimizers (QAOA/VQE prototypes)
+- ELEMENTS/UE: canonical geometric unit elements
+- ELEMENTS/FE: federation elements for cross-domain optimization (e.g., aero-structures coupling)
+- WAVES/FWD: FWD models used for predictive gust response
+- STATES/QS: no active QS artifacts yet — record experiments here
+
+## Local Decisions / Deviations
+- Local decision log: record deviation IDs, reasons, and approval dates here.
+
+## Links / Templates
+- Template bucket: `8-RESOURCES/TEMPLATES/DOMAIN-SPECIFIC-TEMPLATES/AAA-TEMPLATES/`
+- Example artifacts: `3-PROJECTS-USE-CASES/BWB-Q100-AIRCRAFT/`
+
+## Change log
+- Created: [YYYY-MM-DD] by [author]
+- Last updated: [YYYY-MM-DD] — brief note
+""",
+        "AAP-AIRPORT-ADAPTABLE-PLATFORMS": """# AAP — AIRPORT-ADAPTABLE-PLATFORMS
+
+## Purpose & Scope
+Scope: airport adaptability, ground operations interface, scalable platform integration for AMPEL360 and city systems.
+
+## Domain Steward
+- Primary steward: [Team / Person]
+- Contact: [email]
+
+## Interfaces
+- Typical artifacts: station layout DWG, capacity YAML, resource allocation JSON
+- Interfaces with: IIF (infrastructure), LIB (logistics), LCC (communications)
+
+## Compliance & Standards
+- Airport design standards, ICAO ground ops recommendations, local regulatory constraints, S1000D for ground ops maintenance
+
+## Variants & Notable Items
+- Urban micro-hubs, large-scale adaptables, rapid reconfiguration modes
+
+## Quantum Layers Map
+- CB: ground operations classical logic and scheduling
+- QB: reserved for quantum-enabled scheduling optimizers
+- UE/FE: federated elements to map airport ↔ aircraft interactions
+- FWD: predictive passenger flow models
+- QS: N/A (placeholder for future sensors-based quantum inference)
+
+## Local Decisions / Links / Change log
+- As above
+""",
+        "CCC-COCKPIT-CABIN-AND-CARGO": """# CCC — COCKPIT-CABIN-AND-CARGO
+
+## Purpose & Scope
+Scope: human-machine interfaces, cabin systems, cargo handling, ergonomic design, avionics cockpit integration.
+
+## Domain Steward
+- Primary steward: [Team / Person]
+- Contact: [email]
+
+## Interfaces
+- Upstream: IIS (integrated intelligence), EDI (instruments), AAA (airframe)
+- Artifacts: cockpit UI prototypes, cabin interface ICDs, cargo load modeling
+
+## Compliance & Standards
+- Human factors standards, ARP4761 (safety assessment), DO-178C for avionics UI SW considerations
+
+## Variants & Notable Items
+- eVTOL cabin variants, cargo reconfiguration modules
+
+## Quantum Layers Map
+- CB: UI states and config bits
+- QB: investigation into QIE for anomaly detection in systems
+- UE/FE: federated AI models for HMI personalization
+- FWD: predictive passenger comfort models
+- QS: none yet
+
+## Local Decisions / Links / Change log
+- ...
+""",
+        "CQH-CRYOGENICS-QUANTUM-AND-H2": """# CQH — CRYOGENICS-QUANTUM-AND-H2
+
+## Purpose & Scope
+Scope: cryogenic systems, hydrogen storage/handling, quantum cryo-subsystems (cold atom sensors), integration with thermal management.
+
+## Domain Steward
+- Primary steward: [Team / Person]
+- Contact: [email]
+
+## Interfaces
+- Interfaces with: PPP (propulsion H2), EEE (electrification), IIS (Q-sensor data)
+- Artifacts: cryo-system specifications, thermal boundary conditions
+
+## Compliance & Standards
+- Pressure vessel regs, hydrogen handling codes, cryogenic safety guidelines
+
+## Variants & Notable Items
+- High-density H2 tanks, cold atom quantum sensor pods (QB-critical)
+
+## Quantum Layers Map
+- CB: sensor controllers (classical)
+- QB: quantum sensors / experimental qubit hardware metadata
+- UE/FE: unit element definitions for cryo modules, federation elements for distributed thermal control
+- FWD: phase-transition wave models
+- QS: quantum-state capture for sensor readouts (metadata)
+
+## Local Decisions / Links / Change log
+- ...
+""",
+        "DDD-DIGITAL-AND-DATA-DEFENSE": """# DDD — DIGITAL-AND-DATA-DEFENSE
+
+## Purpose & Scope
+Scope: cyber resilience, data governance, secure digital threads, intrusion detection, tamper-proofing.
+
+## Domain Steward
+- Primary steward: [Team / Person]
+- Contact: [email]
+
+## Interfaces
+- Integrates across all domains via OPTIMO-DT, UTCS blockchain, LCC comms
+
+## Compliance & Standards
+- GDPR where applicable, IEC 62443, NIST frameworks, secure boot/chain-of-trust
+
+## Variants & Notable Items
+- Secure enclave designs, QUACHAIN notarization integrations
+
+## Quantum Layers Map
+- CB: classical crypto primitives, keys
+- QB: research into quantum-safe crypto & QKD integrations
+- UE/FE: federation elements for cross-domain key agreements
+- FWD: anomaly wave-detection systems
+- QS: quantum-safe state handling (policy notes)
+
+## Local Decisions / Links / Change log
+- ...
+""",
+        "EDI-ELECTRONICS-DIGITAL-INSTRUMENTS": """# EDI — ELECTRONICS-DIGITAL-INSTRUMENTS
+
+## Purpose & Scope
+Scope: sensors, digital instruments, data acquisition, A/D conversion, instrument calibration.
+
+## Domain Steward
+- Primary steward: [Team / Person]
+- Contact: [email]
+
+## Interfaces
+- Interfaces with IIS (AI), DDD (security), AAA (sensors on airframe)
+
+## Compliance & Standards
+- DO-254 for hardware, calibration standards, EMI/EMC requirements
+
+## Variants & Notable Items
+- Hybrid sensors (classical + quantum readout), sensor fusion nodes
+
+## Quantum Layers Map
+- CB: classical sensor capture
+- QB: quantum-enhanced sensors metadata
+- UE/FE: unit/federation for sensor bundles
+- FWD: predictive sensor drift models
+- QS: state capture for quantum sensor outputs
+
+## Local Decisions / Links / Change log
+- ...
+""",
+        "EEE-ECOLOGICAL-EFFICIENT-ELECTRIFICATION": """# EEE — ECOLOGICAL-EFFICIENT-ELECTRIFICATION
+
+## Purpose & Scope
+Scope: electrification of propulsion/auxiliary systems, lifecycle CO2 accounting, circularity, materials selection.
+
+## Domain Steward
+- Primary steward: [Team / Person]
+- Contact: [email]
+
+## Interfaces
+- PPP (propulsion), MMM (materials), CAF (finance/tokenization for circularity)
+
+## Compliance & Standards
+- Emissions reporting frameworks, ISO 14001, materials compliance
+
+## Variants & Notable Items
+- Hybrid-electric conversions, battery vs H2 trade studies
+
+## Quantum Layers Map
+- CB: energy management logic
+- QB: quantum optimization for grid/charge scheduling (QAOA experiments)
+- UE/FE: federated resource models
+- FWD: predictive load waves
+- QS: optional
+
+## Local Decisions / Links / Change log
+- ...
+""",
+        "EER-ENVIRONMENTAL-EMISSIONS-AND-REMEDIATION": """# EER — ENVIRONMENTAL-EMISSIONS-AND-REMEDIATION
+
+## Purpose & Scope
+Scope: emissions monitoring, environmental remediation subsystems (e.g., Sky Cleaner), carbon accounting, sensors.
+
+## Domain Steward
+- Primary steward: [Team / Person]
+- Contact: [email]
+
+## Interfaces
+- Links to CAF (finance), OPTIMO-DT, EEE (electrification)
+
+## Compliance & Standards
+- Environmental reporting standards, EU directives, sensors calibration
+
+## Variants & Notable Items
+- Sky Cleaner system definitions, airborne remediation payload variants
+
+## Quantum Layers Map
+- CB: telemetry ingest
+- QB: experimental quantum sensors for trace detection
+- UE/FE: federation mapping across aircraft/ground remediation units
+- FWD: contamination spread predictions
+- QS: measurement state captures
+
+## Local Decisions / Links / Change log
+- ...
+""",
+        "IIF-INDUSTRIAL-INFRASTRUCTURE-FACILITIES": """# IIF — INDUSTRIAL-INFRASTRUCTURE-FACILITIES
+
+## Purpose & Scope
+Scope: factory design, logistics footprint, site-level digital twin deployment, maintenance infrastructure.
+
+## Domain Steward
+- Primary steward: [Team / Person]
+- Contact: [email]
+
+## Interfaces
+- CAP (production), LIB (logistics), OPTIMO-DT (digital twin sync)
+
+## Compliance & Standards
+- Occupational safety, manufacturing certifications, environmental
+
+## Variants & Notable Items
+- Modular production cells, sustainable site configurations
+
+## Quantum Layers Map
+- CB: MES systems
+- QB: potential Q-enabled scheduling optimizers
+- UE/FE: federated production cell definitions
+- FWD: throughput wave modeling
+- QS: none
+
+## Local Decisions / Links / Change log
+- ...
+""",
+        "IIS-INTEGRATED-INTELLIGENCE-SOFTWARE": """# IIS — INTEGRATED-INTELLIGENCE-SOFTWARE
+
+## Purpose & Scope
+Scope: onboard & ground AI stacks, QIE (quantum inference engine), model orchestration, agent frameworks.
+
+## Domain Steward
+- Primary steward: [Team / Person]
+- Contact: [email]
+
+## Interfaces
+- CAI (AI integration), DDD (security), OPTIMO-DT (model versioning)
+
+## Compliance & Standards
+- Model traceability standards, MLOps guidelines, data governance
+
+## Variants & Notable Items
+- AMPELLLM agent integrations, AGI-DT prototypes
+
+## Quantum Layers Map
+- CB: classical compute orchestrator
+- QB: QNN experiments, QIE registry
+- UE/FE: federation of models (FE → cross-domain model ensembles)
+- FWD: predictive model waves for mission planning
+- QS: state capture for hybrid classical-quantum models
+
+## Local Decisions / Links / Change log
+- ...
+""",
+        "LCC-LINKAGES-CONTROL-AND-COMMUNICATIONS": """# LCC — LINKAGES-CONTROL-AND-COMMUNICATIONS
+
+## Purpose & Scope
+Scope: network, control loops, comms stacks (satcom, ground links), link-layer resilience.
+
+## Domain Steward
+- Primary steward: [Team / Person]
+- Contact: [email]
+
+## Interfaces
+- Cross-domain link tables, ICDs, latency & throughput SLAs
+
+## Compliance & Standards
+- Communications protocols, spectrum regulations, DO-278 (if applicable)
+
+## Variants & Notable Items
+- Low-latency datalinks, quantum key distribution trials
+
+## Quantum Layers Map
+- CB: classical comms management
+- QB: QKD experiments, entanglement maps for secure links
+- UE/FE: federated link elements across domains
+- FWD: predictive link degradation waves
+- QS: quantum state artifacts for QKD sessions
+
+## Local Decisions / Links / Change log
+- ...
+""",
+        "LIB-LOGISTICS-INVENTORY-AND-BLOCKCHAIN": """# LIB — LOGISTICS-INVENTORY-AND-BLOCKCHAIN
+
+## Purpose & Scope
+Scope: supply chain, inventory management, UTCS (tokenization), logistics optimization.
+
+## Domain Steward
+- Primary steward: [Team / Person]
+- Contact: [email]
+
+## Interfaces
+- CAP (production), CAF (finance/token economics), OPTIMO-DT for provenance
+
+## Compliance & Standards
+- Customs & trade regulations, ISO supply chain standards
+
+## Variants & Notable Items
+- Teknia token models, smart-contract references
+
+## Quantum Layers Map
+- CB: inventory control logic
+- QB: Q-optimizers for routing (exploratory)
+- UE/FE: federation for multi-party supply agreements
+- FWD: forecast wave models for demand
+- QS: none
+
+## Local Decisions / Links / Change log
+- ...
+""",
+        "MMM-MECHANICAL-AND-MATERIAL-MODULES": """# MMM — MECHANICAL-AND-MATERIAL-MODULES
+
+## Purpose & Scope
+Scope: mechanical systems, materials, structural subsystems, fatigue and maintenance considerations.
+
+## Domain Steward
+- Primary steward: [Team / Person]
+- Contact: [email]
+
+## Interfaces
+- AAA (airframe), CAE (simulation), CAS (sustainment)
+
+## Compliance & Standards
+- Materials standards, testing protocols, NADCAP where relevant
+
+## Variants & Notable Items
+- Composite layups, additive manufacturing variants
+
+## Quantum Layers Map
+- CB: FEA job orchestration
+- QB: quantum acceleration for optimization (VQE/QAOA for topology)
+- UE/FE: unit parts & federation for supply variation
+- FWD: fatigue-wave predictive analytics
+- QS: experimental data capture
+
+## Local Decisions / Links / Change log
+- ...
+""",
+        "OOO-OS-ONTOLOGIES-AND-OFFICE-INTERFACES": """# OOO — OS-ONTOLOGIES-AND-OFFICE-INTERFACES
+
+## Purpose & Scope
+Scope: ontologies, data models, office interfaces (APIs), knowledge graphs supporting OPTIMO-DT.
+
+## Domain Steward
+- Primary steward: [Team / Person]
+- Contact: [email]
+
+## Interfaces
+- OPTIMO-DT ingestion, IIS model metadata, 8-RESOURCES references
+
+## Compliance & Standards
+- Ontology best practices, RDF/OWL, metadata schemas
+
+## Variants & Notable Items
+- UTCS ↔ ontology bridges, knowledge-graph federation
+
+## Quantum Layers Map
+- CB: metadata stores (classical)
+- QB: exploring quantum-accelerated graph algorithms
+- UE/FE: federated ontology elements
+- FWD: change-wave forecasting for knowledge drift
+- QS: none
+
+## Local Decisions / Links / Change log
+- ...
+""",
+        "PPP-PROPULSION-AND-FUEL-SYSTEMS": """# PPP — PROPULSION-AND-FUEL-SYSTEMS
+
+## Purpose & Scope
+Scope: propulsion architectures (jet, H2, hybrid-electric), fuel systems, fuel handling & interfaces.
+
+## Domain Steward
+- Primary steward: [Team / Person]
+- Contact: [email]
+
+## Interfaces
+- CQH (H2 storage), EEE (electrification), MMM (mechanical integration), OPTIMO-DT
+
+## Compliance & Standards
+- Propulsion certification norms, fuel handling codes, thermodynamic test standards
+
+## Variants & Notable Items
+- H2 tanks, hybrid-drive integrations, thermal integration packages
+
+## Quantum Layers Map
+- CB: engine control logic
+- QB: experimental quantum optimizers for combustion parameters or scheduling
+- UE/FE: unit elements for engine modules and federation orchestration with fuel supply
+- FWD: thermodynamic fluctuation models
+- QS: research metadata
+
+## Local Decisions / Links / Change log
+- ...
+""",
+    }
+
+    for code, content in stubs.items():
+        path = root / "2-DOMAINS-LEVELS" / code / "TFA" / "META"
+        path.mkdir(parents=True, exist_ok=True)
+        file = path / "README.md"
+        if file.exists():
+            print(f"Skipping existing: {file}")
+        else:
+            file.write_text(content, encoding="utf-8")
+            print(f"Created: {file}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add idea submission for bilayer graphene domain-wall waveguides with initial KWANT simulation stub
- provide script to generate domain META README stubs across all domains

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68c5bc571b888332915c33c6ba8d4b48

## Summary by Sourcery

Add a script to generate META README stubs for all domains, introduce a bilayer graphene domain-wall waveguide research idea submission, and provide an initial KWANT-based simulation stub.

New Features:
- Introduce scripts/create_meta_readmes.py to idempotently generate domain META README stubs.
- Add IDEA_SUBMISSION.md outlining a BLG domain-wall waveguide research proposal with problem statement, solution plan, and success criteria.

Enhancements:
- Include a preliminary KWANT-based simulator stub (dw_transport.py) for bilayer graphene domain-wall transport calculations.

Documentation:
- Provide detailed research documentation for the BLG domain-wall waveguide idea in IDEA_SUBMISSION.md.